### PR TITLE
Fixed processing of all domains request

### DIFF
--- a/lib/rebrandly/api.rb
+++ b/lib/rebrandly/api.rb
@@ -43,7 +43,7 @@ module Rebrandly
     # GET /v1/domains
     def domains(options={})
       all_domains = rebrandly_request(:get, 'domains', options)
-      all_domains.map { Domain.new(all_domains.first) }
+      all_domains.map { |domain| Domain.new(domain) }
     end
 
     # GET /v1/domains/:id


### PR DESCRIPTION
Properly return all domains given by Rebrandly, not just the first domain multiple times